### PR TITLE
fix: 창 최소화 버튼 작동하지 않게 수정 및 doubleClick 작동하지 않도록 stopPropagation 추가

### DIFF
--- a/src/AppWindow.tsx
+++ b/src/AppWindow.tsx
@@ -22,6 +22,9 @@ const AppWindow = (): JSX.Element | null => {
     };
 
     const handleMinimize = (): void => {
+        if (isMaximized) {
+            return;
+        }
         setIsAnimating(true);
         setTimeout(() => {
             setIsMinimized(true);
@@ -42,7 +45,7 @@ const AppWindow = (): JSX.Element | null => {
             {!isMinimized && (
                 <div
                     ref={appWindowRef}
-                    className={`flex flex-col border border-gray-300 rounded-lg overflow-hidden shadow-lg ${isAnimating ? 'minimize-animation' : ''}`}
+                    className={`flex flex-col border border-gray-300 rounded-lg overflow-hidden shadow-lg shadow-black/30 ${isAnimating ? 'minimize-animation' : ''}`}
                     style={{
                         position: 'fixed',
                         width: isMaximized ? windowWidth : w,
@@ -148,6 +151,7 @@ const AppWindow = (): JSX.Element | null => {
                         }, true)}
                     />
                     <AppWindowHeader
+                        isMaximized={isMaximized}
                         appRect={{ x, y, w, h }}
                         onSetAppRect={setAppRect}
                         onClose={handleClose}

--- a/src/AppWindowHeader.tsx
+++ b/src/AppWindowHeader.tsx
@@ -40,6 +40,7 @@ const MaximizeIcon = (): JSX.Element => (
 );
 
 interface AppWindowHeaderProps {
+    isMaximized: boolean;
     appRect: { x: number; y: number; w: number; h: number };
     onSetAppRect: (DOMRect: { x: number; y: number; w: number; h: number }) => void;
     onClose: () => void;
@@ -48,7 +49,7 @@ interface AppWindowHeaderProps {
 }
 
 const AppWindowHeader = (props: AppWindowHeaderProps): JSX.Element => {
-    const { appRect, onSetAppRect, onClose, onMinimize, onMaximize } = props;
+    const { isMaximized, appRect, onSetAppRect, onClose, onMinimize, onMaximize } = props;
 
     return (
         <div
@@ -71,10 +72,11 @@ const AppWindowHeader = (props: AppWindowHeaderProps): JSX.Element => {
                     <CloseIcon />
                 </button>
                 <button
-                    className={`relative w-3 h-3 rounded-full bg-yellow-500 group flex items-center justify-center`}
+                    className={`relative w-3 h-3 rounded-full ${isMaximized ? 'bg-gray-500' : 'bg-yellow-500'} group flex items-center justify-center`}
                     onClick={onMinimize}
+                    onDoubleClick={(e) => e.stopPropagation()}
                 >
-                    <MinimizeIcon />
+                    {!isMaximized && <MinimizeIcon />}
                 </button>
                 <button
                     className={`relative w-3 h-3 rounded-full bg-green-500 group flex items-center justify-center`}


### PR DESCRIPTION
- 문제: 창이 최대인 경우 최소화시키는 동작은 막았지만, 더블 클릭 시 발생하는 maximize 동작을 함. 
- 해결: 해당 요소에서 더블 클릭 이벤트가 발생했을 때 상위 요소로의 이벤트 전파를 막아, 상위 요소에 연결된 더블 클릭 이벤트가 실행되지 않도록 수정.
---
- react의 이벤트는 기본적으로 **버블링**과 **캡쳐링**이 활성화 되어있음.
- **버블링**
  - 이벤트가 발생한 요소에서 시작하여 상위 요소로 이벤트가 전파되는 것.
  - ex) 버튼을 클릭하면 클릭 이벤트 발생히고, 해당 버튼을 포함한 상위 요소에 대해서도 클릭 이벤트 발생
- `e.stopPropagation()`: 이벤트 버블링을 중지시키는 메서드
  - 현재 이벤트가 상위 요소로 전파되지 않고 현재 요소에서 중단됨.
 
