### PR TITLE
refactor: AppWindow의 Resize 및 Drag 기능하는 RnD 컴포넌트 생성

### DIFF
--- a/src/AppWindow.tsx
+++ b/src/AppWindow.tsx
@@ -1,11 +1,10 @@
 import { useRef, useState } from 'react';
 import AppWindowHeader from './AppWindowHeader';
+import RnD from './components/RnD';
 import { useWindowSize } from './hooks/useWindowSize';
-import { inrange } from './utils';
-import { registerDragEvent } from './utils/registerDragEvent';
 
-const MIN_WIDTH = 500;
-const MIN_HEIGHT = 400;
+export const MIN_WIDTH = 500;
+export const MIN_HEIGHT = 400;
 
 const AppWindow = (): JSX.Element | null => {
     const appWindowRef = useRef<HTMLDivElement>(null);
@@ -43,113 +42,21 @@ const AppWindow = (): JSX.Element | null => {
     return (
         <>
             {!isMinimized && (
-                <div
+                <RnD
                     ref={appWindowRef}
-                    className={`flex flex-col border border-gray-300 rounded-lg overflow-hidden shadow-lg shadow-black/30 ${isAnimating ? 'minimize-animation' : ''}`}
-                    style={{
-                        position: 'fixed',
+                    size={{
                         width: isMaximized ? windowWidth : w,
                         height: isMaximized ? windowHeight : h,
-                        left: isMaximized ? 0 : x,
-                        top: isMaximized ? 0 : y,
                     }}
+                    position={{
+                        x: isMaximized ? 0 : x,
+                        y: isMaximized ? 0 : y,
+                    }}
+                    windowWidth={windowWidth}
+                    windowHeight={windowHeight}
+                    updateRnDRect={setAppRect}
+                    className={`flex flex-col border border-gray-300 rounded-lg overflow-hidden shadow-lg shadow-black/30 ${isAnimating ? 'minimize-animation' : ''}`}
                 >
-                    {/* 좌상단 */}
-                    <div
-                        className="absolute -top-1 -left-1 h-4 w-4 cursor-nw-resize"
-                        {...registerDragEvent((deltaX, deltaY) => {
-                            setAppRect({
-                                x: inrange(x + deltaX, 0, x + w - MIN_WIDTH),
-                                y: inrange(y + deltaY, 0, y + h - MIN_HEIGHT),
-                                w: inrange(w - deltaX, MIN_WIDTH, x + w),
-                                h: inrange(h - deltaY, MIN_HEIGHT, y + h),
-                            });
-                        }, true)}
-                    />
-                    {/* 우상단 */}
-                    <div
-                        className="absolute -top-1 -right-1 h-4 w-4 cursor-ne-resize"
-                        {...registerDragEvent((deltaX, deltaY) => {
-                            setAppRect({
-                                x,
-                                y: inrange(y + deltaY, 0, y + h - MIN_HEIGHT),
-                                w: inrange(w + deltaX, MIN_WIDTH, windowWidth - x),
-                                h: inrange(h - deltaY, MIN_HEIGHT, y + h),
-                            });
-                        }, true)}
-                    />
-                    {/* 좌하단 */}
-                    <div
-                        className="absolute -bottom-1 -left-1 h-4 w-4 cursor-sw-resize"
-                        {...registerDragEvent((deltaX, deltaY) => {
-                            setAppRect({
-                                x: inrange(x + deltaX, 0, x + w - MIN_WIDTH),
-                                y,
-                                w: inrange(w - deltaX, MIN_WIDTH, x + w),
-                                h: inrange(h + deltaY, MIN_HEIGHT, windowHeight - y),
-                            });
-                        }, true)}
-                    />
-                    {/* 우하단 */}
-                    <div
-                        className="absolute -bottom-1 -right-1 h-4 w-4 cursor-se-resize"
-                        {...registerDragEvent((deltaX, deltaY) => {
-                            setAppRect({
-                                x,
-                                y,
-                                w: inrange(w + deltaX, MIN_WIDTH, windowWidth - x),
-                                h: inrange(h + deltaY, MIN_HEIGHT, windowHeight - y),
-                            });
-                        }, true)}
-                    />
-                    {/* 상 */}
-                    <div
-                        className="absolute -top-0.5 left-3 right-3 h-2 cursor-n-resize"
-                        {...registerDragEvent((_, deltaY) => {
-                            setAppRect({
-                                x,
-                                y: inrange(y + deltaY, 0, y + h - MIN_HEIGHT),
-                                w,
-                                h: inrange(h - deltaY, MIN_HEIGHT, y + h),
-                            });
-                        }, true)}
-                    />
-                    {/* 하 */}
-                    <div
-                        className="absolute -bottom-0.5 left-3 right-3 h-2 cursor-s-resize"
-                        {...registerDragEvent((_, deltaY) => {
-                            setAppRect({
-                                x,
-                                y,
-                                w,
-                                h: inrange(h + deltaY, MIN_HEIGHT, windowHeight - y),
-                            });
-                        }, true)}
-                    />
-                    {/* 좌 */}
-                    <div
-                        className="absolute bottom-3 top-3 -left-0.5 w-2 cursor-w-resize"
-                        {...registerDragEvent((deltaX, _) => {
-                            setAppRect({
-                                x: inrange(x + deltaX, 0, x + w - MIN_WIDTH),
-                                y,
-                                w: inrange(w - deltaX, MIN_WIDTH, x + w),
-                                h,
-                            });
-                        }, true)}
-                    />
-                    {/* 우 */}
-                    <div
-                        className="absolute bottom-3 top-3 -right-0.5 w-2 cursor-e-resize"
-                        {...registerDragEvent((deltaX, _) => {
-                            setAppRect({
-                                x,
-                                y,
-                                w: inrange(w + deltaX, MIN_WIDTH, windowWidth - x),
-                                h,
-                            });
-                        }, true)}
-                    />
                     <AppWindowHeader
                         isMaximized={isMaximized}
                         appRect={{ x, y, w, h }}
@@ -158,10 +65,10 @@ const AppWindow = (): JSX.Element | null => {
                         onMinimize={handleMinimize}
                         onMaximize={handleMaximize}
                     />
-                    <div className="flex-grow bg-white p-4">
+                    <div className="main-content flex-grow bg-white p-4">
                         <p>This is the window content.</p>
                     </div>
-                </div>
+                </RnD>
             )}
         </>
     );

--- a/src/components/RnD.tsx
+++ b/src/components/RnD.tsx
@@ -1,0 +1,125 @@
+import type { Ref } from 'react';
+import { forwardRef } from 'react';
+import { MIN_HEIGHT, MIN_WIDTH } from '../AppWindow';
+import { inrange } from '../utils';
+import { registerDragEvent } from '../utils/registerDragEvent';
+
+interface RnDProps {
+    size: { width: number; height: number };
+    position: { x: number; y: number };
+    children?: React.ReactNode;
+    className?: string;
+    windowWidth: number;
+    windowHeight: number;
+    updateRnDRect: (RnDRect: { x: number; y: number; w: number; h: number }) => void;
+}
+
+const RnD = forwardRef((props: RnDProps, ref: Ref<HTMLDivElement>): JSX.Element => {
+    const { size, position, children, className, updateRnDRect, windowWidth, windowHeight } = props;
+    const { width: w, height: h } = size;
+    const { x, y } = position;
+
+    return (
+        <div ref={ref} style={{ position: 'fixed', width: w, height: h, left: x, top: y }} className={className}>
+            {/* 좌상단 */}
+            <div
+                className="absolute -top-1 -left-1 h-4 w-4 cursor-nw-resize"
+                {...registerDragEvent((deltaX, deltaY) => {
+                    updateRnDRect({
+                        x: inrange(x + deltaX, 0, x + w - MIN_WIDTH),
+                        y: inrange(y + deltaY, 0, y + h - MIN_HEIGHT),
+                        w: inrange(w - deltaX, MIN_WIDTH, x + w),
+                        h: inrange(h - deltaY, MIN_HEIGHT, y + h),
+                    });
+                }, true)}
+            />
+            {/* 우상단 */}
+            <div
+                className="absolute -top-1 -right-1 h-4 w-4 cursor-ne-resize"
+                {...registerDragEvent((deltaX, deltaY) => {
+                    updateRnDRect({
+                        x,
+                        y: inrange(y + deltaY, 0, y + h - MIN_HEIGHT),
+                        w: inrange(w + deltaX, MIN_WIDTH, windowWidth - x),
+                        h: inrange(h - deltaY, MIN_HEIGHT, y + h),
+                    });
+                }, true)}
+            />
+            {/* 좌하단 */}
+            <div
+                className="absolute -bottom-1 -left-1 h-4 w-4 cursor-sw-resize"
+                {...registerDragEvent((deltaX, deltaY) => {
+                    updateRnDRect({
+                        x: inrange(x + deltaX, 0, x + w - MIN_WIDTH),
+                        y,
+                        w: inrange(w - deltaX, MIN_WIDTH, x + w),
+                        h: inrange(h + deltaY, MIN_HEIGHT, windowHeight - y),
+                    });
+                }, true)}
+            />
+            {/* 우하단 */}
+            <div
+                className="absolute -bottom-1 -right-1 h-4 w-4 cursor-se-resize"
+                {...registerDragEvent((deltaX, deltaY) => {
+                    updateRnDRect({
+                        x,
+                        y,
+                        w: inrange(w + deltaX, MIN_WIDTH, windowWidth - x),
+                        h: inrange(h + deltaY, MIN_HEIGHT, windowHeight - y),
+                    });
+                }, true)}
+            />
+            {/* 상 */}
+            <div
+                className="absolute -top-0.5 left-3 right-3 h-2 cursor-n-resize"
+                {...registerDragEvent((_, deltaY) => {
+                    updateRnDRect({
+                        x,
+                        y: inrange(y + deltaY, 0, y + h - MIN_HEIGHT),
+                        w,
+                        h: inrange(h - deltaY, MIN_HEIGHT, y + h),
+                    });
+                }, true)}
+            />
+            {/* 하 */}
+            <div
+                className="absolute -bottom-0.5 left-3 right-3 h-2 cursor-s-resize"
+                {...registerDragEvent((_, deltaY) => {
+                    updateRnDRect({
+                        x,
+                        y,
+                        w,
+                        h: inrange(h + deltaY, MIN_HEIGHT, windowHeight - y),
+                    });
+                }, true)}
+            />
+            {/* 좌 */}
+            <div
+                className="absolute bottom-3 top-3 -left-0.5 w-2 cursor-w-resize"
+                {...registerDragEvent((deltaX, _) => {
+                    updateRnDRect({
+                        x: inrange(x + deltaX, 0, x + w - MIN_WIDTH),
+                        y,
+                        w: inrange(w - deltaX, MIN_WIDTH, x + w),
+                        h,
+                    });
+                }, true)}
+            />
+            {/* 우 */}
+            <div
+                className="absolute bottom-3 top-3 -right-0.5 w-2 cursor-e-resize"
+                {...registerDragEvent((deltaX, _) => {
+                    updateRnDRect({
+                        x,
+                        y,
+                        w: inrange(w + deltaX, MIN_WIDTH, windowWidth - x),
+                        h,
+                    });
+                }, true)}
+            />
+            {children}
+        </div>
+    );
+});
+
+export default RnD;


### PR DESCRIPTION
- RnD 컴포넌트에서 부모 컴포넌트로부터 ref를 받기 위해 React의 forwardRef API를 사용
  - RnD 컴포넌트 내부의 div 엘리먼트에 참조를 전달
- AppWindow 컴포넌트 자체의 가독성이 높아지고, Resize 및 Drag가 진행되는 element 분리 효과
- TODO:: 리팩토링 RnD 컴포넌트 - (상위 컴포넌트에서 적정 크기를 조절하는 부분이 필요하기에) 완전한 추상화는 아님. 