### PR TITLE
add: 선택한 AppWindow가 최상위에 위치하도록 z-index 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,7 +68,7 @@ const App = (): JSX.Element => {
         <div className="bg-light dark:bg-dark bg-cover h-screen w-screen">
             <button onClick={darkSetButton}>{dark ? 'Dark Mode' : 'Light Mode'}</button>
             {apps.map((app) => (
-                <AppWindow key={app.id} zIndex={app.zIndex} onZindex={() => handleZIndex(app.id)}>
+                <AppWindow key={app.id} title={app.title} zIndex={app.zIndex} onZindex={() => handleZIndex(app.id)}>
                     <p>{app.title}</p>
                 </AppWindow>
             ))}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,11 +32,20 @@ const App = (): JSX.Element => {
         }
     }, [dark]);
 
+    /**
+     * TODO:
+     * 선택한 AppWindow가 가장 최상단에 위치하도록
+     * 하나의 AppWindow만 Maximize 가능하도록
+     */
     return (
         <div className="bg-light dark:bg-dark bg-cover h-screen w-screen">
             <button onClick={darkSetButton}>{dark ? 'Dark Mode' : 'Light Mode'}</button>
-
-            <AppWindow />
+            <AppWindow>
+                <p>Window 1</p>
+            </AppWindow>
+            <AppWindow>
+                <p>Window 2</p>
+            </AppWindow>
         </div>
     );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,39 @@ import { useEffect, useState } from 'react';
 import AppWindow from './AppWindow';
 import { safeLocalStorage } from './utils/storage';
 
+interface Apps {
+    id: number;
+    title: string;
+    zIndex: number;
+}
+
 const App = (): JSX.Element => {
+    const initialApps: Apps[] = [
+        { id: 1, title: 'App 1', zIndex: 1 },
+        { id: 2, title: 'App 2', zIndex: 2 },
+        { id: 3, title: 'App 3', zIndex: 3 },
+    ];
+    const [apps, setApps] = useState(initialApps);
+    const [highestZIndex, setHighestZIndex] = useState(initialApps.length);
+
+    const handleZIndex = (id: number): void => {
+        // 클릭된 AppWindow의 zIndex를 높임
+        setApps((prevApps): Apps[] => {
+            const clickedApp = prevApps.find((app) => app.id === id);
+
+            // 클릭한 App이 이미 가장 높은 zIndex를 가지고 있다면 highestZIndex가 변경될 필요 x
+            if (clickedApp && clickedApp.zIndex === highestZIndex) {
+                return prevApps;
+            }
+
+            const newApps = prevApps.map((app) => (app.id === id ? { ...app, zIndex: highestZIndex + 1 } : app));
+            // 최고 zIndex 값 업데이트
+            setHighestZIndex(highestZIndex + 1);
+
+            return newApps;
+        });
+    };
+
     const localStorageChecker = (): boolean => {
         const theme = safeLocalStorage.getItem('theme');
         return theme === 'dark';
@@ -32,20 +64,14 @@ const App = (): JSX.Element => {
         }
     }, [dark]);
 
-    /**
-     * TODO:
-     * 선택한 AppWindow가 가장 최상단에 위치하도록
-     * 하나의 AppWindow만 Maximize 가능하도록
-     */
     return (
         <div className="bg-light dark:bg-dark bg-cover h-screen w-screen">
             <button onClick={darkSetButton}>{dark ? 'Dark Mode' : 'Light Mode'}</button>
-            <AppWindow>
-                <p>Window 1</p>
-            </AppWindow>
-            <AppWindow>
-                <p>Window 2</p>
-            </AppWindow>
+            {apps.map((app) => (
+                <AppWindow key={app.id} zIndex={app.zIndex} onZindex={() => handleZIndex(app.id)}>
+                    <p>{app.title}</p>
+                </AppWindow>
+            ))}
         </div>
     );
 };

--- a/src/AppWindow.tsx
+++ b/src/AppWindow.tsx
@@ -7,13 +7,14 @@ export const MIN_WIDTH = 500;
 export const MIN_HEIGHT = 400;
 
 interface AppWindowProps {
+    title: string;
     zIndex: number;
     onZindex: () => void;
     children: React.ReactNode;
 }
 
 const AppWindow = (props: AppWindowProps): JSX.Element | null => {
-    const { zIndex, onZindex, children } = props;
+    const { title, zIndex, onZindex, children } = props;
     const appWindowRef = useRef<HTMLDivElement>(null);
     const { width: windowWidth, height: windowHeight } = useWindowSize();
     const [{ x, y, w, h }, setAppRect] = useState({ x: 100, y: 100, w: MIN_WIDTH, h: MIN_HEIGHT });
@@ -66,9 +67,10 @@ const AppWindow = (props: AppWindowProps): JSX.Element | null => {
                     windowHeight={windowHeight}
                     updateRnDRect={setAppRect}
                     className={`flex flex-col border border-gray-300 rounded-lg overflow-hidden shadow-lg shadow-black/30 ${isAnimating ? 'minimize-animation' : ''}`}
-                    onClick={onZindex}
+                    onZindex={onZindex}
                 >
                     <AppWindowHeader
+                        title={title}
                         isMaximized={isMaximized}
                         appRect={{ x, y, w, h }}
                         onSetAppRect={setAppRect}

--- a/src/AppWindow.tsx
+++ b/src/AppWindow.tsx
@@ -6,7 +6,11 @@ import { useWindowSize } from './hooks/useWindowSize';
 export const MIN_WIDTH = 500;
 export const MIN_HEIGHT = 400;
 
-const AppWindow = (): JSX.Element | null => {
+interface AppWindowProps {
+    children: React.ReactNode;
+}
+
+const AppWindow = (props: AppWindowProps): JSX.Element | null => {
     const appWindowRef = useRef<HTMLDivElement>(null);
     const { width: windowWidth, height: windowHeight } = useWindowSize();
     const [{ x, y, w, h }, setAppRect] = useState({ x: 100, y: 100, w: MIN_WIDTH, h: MIN_HEIGHT });
@@ -67,9 +71,7 @@ const AppWindow = (): JSX.Element | null => {
                         onMinimize={handleMinimize}
                         onMaximize={handleMaximize}
                     />
-                    <div className="main-content flex-grow bg-white p-4">
-                        <p>This is the window content.</p>
-                    </div>
+                    <div className="main-content flex-grow bg-white p-4">{props.children}</div>
                 </RnD>
             )}
         </>

--- a/src/AppWindow.tsx
+++ b/src/AppWindow.tsx
@@ -7,10 +7,13 @@ export const MIN_WIDTH = 500;
 export const MIN_HEIGHT = 400;
 
 interface AppWindowProps {
+    zIndex: number;
+    onZindex: () => void;
     children: React.ReactNode;
 }
 
 const AppWindow = (props: AppWindowProps): JSX.Element | null => {
+    const { zIndex, onZindex, children } = props;
     const appWindowRef = useRef<HTMLDivElement>(null);
     const { width: windowWidth, height: windowHeight } = useWindowSize();
     const [{ x, y, w, h }, setAppRect] = useState({ x: 100, y: 100, w: MIN_WIDTH, h: MIN_HEIGHT });
@@ -56,12 +59,14 @@ const AppWindow = (props: AppWindowProps): JSX.Element | null => {
                         x: isMaximized ? 0 : x,
                         y: isMaximized ? 0 : y,
                     }}
+                    zIndex={zIndex}
                     minWidth={MIN_WIDTH}
                     minHeight={MIN_HEIGHT}
                     windowWidth={windowWidth}
                     windowHeight={windowHeight}
                     updateRnDRect={setAppRect}
                     className={`flex flex-col border border-gray-300 rounded-lg overflow-hidden shadow-lg shadow-black/30 ${isAnimating ? 'minimize-animation' : ''}`}
+                    onClick={onZindex}
                 >
                     <AppWindowHeader
                         isMaximized={isMaximized}
@@ -71,7 +76,7 @@ const AppWindow = (props: AppWindowProps): JSX.Element | null => {
                         onMinimize={handleMinimize}
                         onMaximize={handleMaximize}
                     />
-                    <div className="main-content flex-grow bg-white p-4">{props.children}</div>
+                    <div className="main-content flex-grow bg-white p-4">{children}</div>
                 </RnD>
             )}
         </>

--- a/src/AppWindowHeader.tsx
+++ b/src/AppWindowHeader.tsx
@@ -40,6 +40,7 @@ const MaximizeIcon = (): JSX.Element => (
 );
 
 interface AppWindowHeaderProps {
+    title: string;
     isMaximized: boolean;
     appRect: { x: number; y: number; w: number; h: number };
     onSetAppRect: (DOMRect: { x: number; y: number; w: number; h: number }) => void;
@@ -49,7 +50,7 @@ interface AppWindowHeaderProps {
 }
 
 const AppWindowHeader = (props: AppWindowHeaderProps): JSX.Element => {
-    const { isMaximized, appRect, onSetAppRect, onClose, onMinimize, onMaximize } = props;
+    const { title, isMaximized, appRect, onSetAppRect, onClose, onMinimize, onMaximize } = props;
 
     return (
         <div
@@ -86,7 +87,7 @@ const AppWindowHeader = (props: AppWindowHeaderProps): JSX.Element => {
                 </button>
             </div>
             <div className="text-center flex-1">
-                <span className="text-sm text-gray-700">Apple Window</span>
+                <span className="text-sm text-gray-700">{title}</span>
             </div>
             <div className="w-12"></div>
         </div>

--- a/src/components/RnD.tsx
+++ b/src/components/RnD.tsx
@@ -14,7 +14,7 @@ interface RnDProps {
     windowWidth: number;
     windowHeight: number;
     updateRnDRect: (RnDRect: { x: number; y: number; w: number; h: number }) => void;
-    onClick: () => void;
+    onZindex: () => void;
 }
 
 const RnD = forwardRef((props: RnDProps, ref: Ref<HTMLDivElement>): JSX.Element => {
@@ -29,7 +29,7 @@ const RnD = forwardRef((props: RnDProps, ref: Ref<HTMLDivElement>): JSX.Element 
         windowWidth,
         windowHeight,
         updateRnDRect,
-        onClick,
+        onZindex,
     } = props;
     const { width: w, height: h } = size;
     const { x, y } = position;
@@ -39,7 +39,7 @@ const RnD = forwardRef((props: RnDProps, ref: Ref<HTMLDivElement>): JSX.Element 
             ref={ref}
             style={{ position: 'fixed', width: w, height: h, left: x, top: y, zIndex: zIndex }}
             className={className}
-            onClick={onClick}
+            onMouseDown={onZindex}
         >
             {/* 좌상단 */}
             <div

--- a/src/components/RnD.tsx
+++ b/src/components/RnD.tsx
@@ -6,6 +6,7 @@ import { registerDragEvent } from '../utils/registerDragEvent';
 interface RnDProps {
     size: { width: number; height: number };
     position: { x: number; y: number };
+    zIndex: number;
     children?: React.ReactNode;
     className?: string;
     minWidth: number;
@@ -13,16 +14,33 @@ interface RnDProps {
     windowWidth: number;
     windowHeight: number;
     updateRnDRect: (RnDRect: { x: number; y: number; w: number; h: number }) => void;
+    onClick: () => void;
 }
 
 const RnD = forwardRef((props: RnDProps, ref: Ref<HTMLDivElement>): JSX.Element => {
-    const { size, position, children, className, minWidth, minHeight, windowWidth, windowHeight, updateRnDRect } =
-        props;
+    const {
+        size,
+        position,
+        zIndex,
+        children,
+        className,
+        minWidth,
+        minHeight,
+        windowWidth,
+        windowHeight,
+        updateRnDRect,
+        onClick,
+    } = props;
     const { width: w, height: h } = size;
     const { x, y } = position;
 
     return (
-        <div ref={ref} style={{ position: 'fixed', width: w, height: h, left: x, top: y }} className={className}>
+        <div
+            ref={ref}
+            style={{ position: 'fixed', width: w, height: h, left: x, top: y, zIndex: zIndex }}
+            className={className}
+            onClick={onClick}
+        >
             {/* 좌상단 */}
             <div
                 className="absolute -top-1 -left-1 h-4 w-4 cursor-nw-resize"


### PR DESCRIPTION
- 기대 적용 방향 : 클릭한 창이 최상단에 위치하도록 하는 기능
---
- 여러 앱이 생성될 수 있기에 임의적으로 initialApps 배열 생성.
- z-index의 숫자가 높을 수록 가장 높이 위치하게 됨.
- 클릭된 AppWindow의 z-index가 이미 최고인 경우, 상태를 업데이트하지 않아 불필요한 렌더링을 방지.
- 또한 선택된 AppWindow가 onClick 이벤트가 아닌 onMouseDown으로 z-index 변경 사항을 컨트롤함.
  -  **뒷편에 위치한 AppWindow를 drag 할 때도** 딜레이 없이 z-index가 적용됨. 
  - (*onClick으로 z-index 변경 함수를 적용했을 경우, mouse up이 되지 않는 이상 최상위 z-index가 적용이 안 되는 문제가 있었음.)